### PR TITLE
Add setup and deploy instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Metatoken extensions act as nested ERC-1155 contracts that exist to support and 
 
 RC-1155M contracts provide hooks into the mutability actions of ERC-1155 tokens. Each extension can be registered against any number of actions, and must provide appropriate external functions for these hooks. The ERC-1155M contract provides two hooks for each action: pre-action and post-action. This results in a total of 6 groups and 12 hooks for extensions to implement; however, they must implement both the pre-action and post-action hooks for the specific action they are registered for, with a minimum of one action per extension (see: IMetatoken1155). Hooks may revert if applicable, but the pre-action hooks’ mutability must be either view or pure.
 
+[Read the whitepaper](./ERC-1155%20Metatokens.pdf)
+
 ## setup
 
 - ensure `node` and `python` are installed and on your path
@@ -14,7 +16,11 @@ RC-1155M contracts provide hooks into the mutability actions of ERC-1155 tokens.
 - choose `Terminal > Run Build Task...` to run all the watch tasks simultaneously. If you run into errors, you may need to restart one of the watches due to potential race conditions.
 - you can also run one or more separately in a terminal
 
-Run `yarn build` to compile the scripts and `yarn script:tsc-alias` to ensure that the path aliases are updated correctly.
+Here are the manual steps to run the tests:
+
+- run `yarn build` once to generate `./tsc-alias-replacers/replacerA.js` (you'll see an error about "replacerA.ts is not under `rootDir")
+- run `yarn build:tsc-alias`
+- run `yarn test` to run tests
 
 ## development
 
@@ -27,6 +33,8 @@ To improve debugging of `delegatecall`, patch the hardhat network according to `
 - `yarn genabi:watch` - updates generated contract abis when contracts are changed
 - `yarn flatten:watch` - automatically generates flattened, single-source contract files
 - `yarn test:watch` - restarts tests whenever a test file or contract is updated
-- `yarn script:tsc-alias` - updates the import paths for the hardhat scripts
 
-## deployment / minting scripts
+## deployment
+
+- run `yarn flatten`
+- deploy via Remix

--- a/README.md
+++ b/README.md
@@ -36,5 +36,14 @@ To improve debugging of `delegatecall`, patch the hardhat network according to `
 
 ## deployment
 
-- run `yarn flatten`
-- deploy via Remix
+There are two primary contracts:
+
+- the main contract `ERC1155M.sol` which should be a drop-in replacement for a standard ERC1155
+- the metatoken extension contract `Metatoken155.sol` which supports the additional metatoken features
+
+Deploy via:
+
+- `rm tools/.flattencache` # to build from scratch if desired
+- `yarn flatten`
+- deploy `flattened/ERC-1155M/ERC1155M_flattened.sol` via Remix
+- deploy `flattened/metatokens/ERC20Metatoken_flattened.sol` via Remix

--- a/README.md
+++ b/README.md
@@ -45,5 +45,8 @@ Deploy via:
 
 - `rm tools/.flattencache` # to build from scratch if desired
 - `yarn flatten`
-- deploy `flattened/ERC-1155M/ERC1155M_flattened.sol` via Remix
-- deploy `flattened/metatokens/ERC20Metatoken_flattened.sol` via Remix
+- compile, deploy and verify `flattened/ERC-1155M/ERC1155M_flattened.sol` or `flattened/metatokens/ERC20Metatoken_flattened.sol`
+  - head over to https://remix.ethereum.org/
+  - copy contract in
+  - compile and deploy via VM (for testing) or wallet (for deploying to chain)
+  - after deploy, in Remix UI, click on gear to add the "ETHERSCAN - CONTRACT VERIFICATION" plugin. Add your etherscan API key and you can verify the contract (and upload contract source)

--- a/README.md
+++ b/README.md
@@ -6,13 +6,21 @@ Metatoken extensions act as nested ERC-1155 contracts that exist to support and 
 
 RC-1155M contracts provide hooks into the mutability actions of ERC-1155 tokens. Each extension can be registered against any number of actions, and must provide appropriate external functions for these hooks. The ERC-1155M contract provides two hooks for each action: pre-action and post-action. This results in a total of 6 groups and 12 hooks for extensions to implement; however, they must implement both the pre-action and post-action hooks for the specific action they are registered for, with a minimum of one action per extension (see: IMetatoken1155). Hooks may revert if applicable, but the pre-action hooks’ mutability must be either view or pure.
 
-# development
+## setup
 
-Run `yarn install --frozen-lockfile` to install all packages.
+- ensure `node` and `python` are installed and on your path
+- run `yarn install --frozen-lockfile` to install all packages.
+- open `metatokens.code-workspace` in VSCode
+- choose `Terminal > Run Build Task...` to run all the watch tasks simultaneously. If you run into errors, you may need to restart one of the watches due to potential race conditions.
+- you can also run one or more separately in a terminal
+
+Run `yarn build` to compile the scripts and `yarn script:tsc-alias` to ensure that the path aliases are updated correctly.
+
+## development
 
 To improve debugging of `delegatecall`, patch the hardhat network according to `hardhat_patch.js`.
 
-# scripts
+## scripts
 
 - `yarn build` - compiles the tests
 - `yarn build:tsc-alias` - updates the import paths in the compiled tests
@@ -21,8 +29,4 @@ To improve debugging of `delegatecall`, patch the hardhat network according to `
 - `yarn test:watch` - restarts tests whenever a test file or contract is updated
 - `yarn script:tsc-alias` - updates the import paths for the hardhat scripts
 
-# deployment / minting scripts
-
-# setup
-
-Run `yarn build` to compile the scripts and `yarn script:tsc-alias` to ensure that the path aliases are updated correctly.
+## deployment / minting scripts

--- a/package.json
+++ b/package.json
@@ -11,13 +11,7 @@
         "genabi": "python tools/generate_abi_typings.py",
         "genabi:watch": "nodemon -w artifacts -e json --delay 1000ms --exec yarn --silent genabi",
         "diff": "node tools/diff_openzeppelin.js",
-        "build-local-eslint": "yarn --silent run tsc --pretty --project eslint-local-rules/tsconfig.json",
-        "script:tsc-alias": "tsc-alias -r ./scripts/tsc-alias-replacer.js -f -w -p tsconfig.other.json --dir scripts",
-        "script:deploy": "hardhat run scripts/deployWIVCore.js",
-        "script:mint-core": "hardhat run scripts/mintWIVCore.js",
-        "script:mint-wivx": "hardhat run scripts/mintWIVX.js",
-        "script:upgrade-core": "hardhat run scripts/upgradeWIVCore.js",
-        "script:upgrade-wivx": "hardhat run scripts/upgradeWIVX.js"
+        "build-local-eslint": "yarn --silent run tsc --pretty --project eslint-local-rules/tsconfig.json"
     },
     "devDependencies": {
         "@nomiclabs/hardhat-ethers": "^2.0.5",

--- a/tools/flatten_all.py
+++ b/tools/flatten_all.py
@@ -43,7 +43,7 @@ def flatten(root, file):
         #p = Popen("yarn", args=["hardhat", "flatten", src, ">", dest])
         #p.wait()
         #system("yarn hardhat flatten %s > %s" % (src, dest))
-        p = run(["yarn", "--silent", "hardhat", "flatten", src], shell=True, stdout=PIPE)
+        p = run(["yarn", "--silent", "hardhat", "flatten", src], shell=False, stdout=PIPE)
         flattened = p.stdout.decode("utf-8")
     except Exception as e:
         print("Could not flatten: %s" % src)


### PR DESCRIPTION
- [x] Add instructions for first time developer setup, build and running tests. Add missing `abi` folder to repo.
- [x] Add link to whitepaper
- [x] Removed missing scripts
- [x] Fix flattening process -- see below
- [x] Document deployment of main contract `ERC1155M.sol` (which should be a drop-in replacement for a standard ERC1155
- [x] Document deployment of metatoken contract `Metatoken155.sol`
- [x] Test deploy ERC1155M

## Flattening Fix details

`flatten_all.py` was generating non-code files like this:

```
// SPDX-License-Identifier: UNLICENSED
pragma solidity ^0.8.13;
[1/4] Resolving packages...
success Already up-to-date.
```

Debugged and fixed script to output flatted solidity files.